### PR TITLE
feat: implement deep trace analysis for agentic workflow failures

### DIFF
--- a/fails/pipeline.py
+++ b/fails/pipeline.py
@@ -34,6 +34,8 @@ from fails.cli.header import get_fails_header_for_rich
 from fails.prompts import (
     CLUSTERING_PROMPT,
     CLUSTERING_SYSTEM_PROMPT,
+    DEFAULT_COMPACTION_MODEL,
+    EXECUTION_TRACE_SECTION,
     FINAL_CLASSIFICATION_PROMPT,
     FINAL_CLASSIFICATION_SYSTEM_PROMPT,
     FIRST_PASS_CATEGORIZATION_PROMPT,
@@ -944,6 +946,7 @@ def construct_first_pass_categorization_prompt(
     row_output: dict | str,
     evaluation_evaluation_or_scorer_data: dict | str,
     user_context: str,
+    execution_trace: str | None = None,
 ) -> str:
     # Convert to JSON strings if needed
     if isinstance(row_input, dict):
@@ -955,11 +958,20 @@ def construct_first_pass_categorization_prompt(
             evaluation_evaluation_or_scorer_data, indent=2
         )
 
+    # Build execution trace section if provided
+    if execution_trace:
+        execution_trace_section = EXECUTION_TRACE_SECTION.format(
+            execution_trace=execution_trace
+        )
+    else:
+        execution_trace_section = ""
+
     first_pass_categorization_prompt_str = FIRST_PASS_CATEGORIZATION_PROMPT.format(
         user_context=user_context,
         row_input=row_input,
         row_output=row_output,
         evaluation_evaluation_or_scorer_data=evaluation_evaluation_or_scorer_data,
+        execution_trace_section=execution_trace_section,
     )
     return first_pass_categorization_prompt_str
 
@@ -974,6 +986,7 @@ async def draft_categorization(
     model: str,
     llm_semaphore: Semaphore,
     debug: bool = False,
+    execution_trace: str | None = None,
 ) -> FirstPassCategorizationResult:
     async with llm_semaphore:
         draft_categorization_llm = Agent(
@@ -988,6 +1001,7 @@ async def draft_categorization(
             row_input=row_input,
             row_output=row_output,
             evaluation_evaluation_or_scorer_data=evaluation_evaluation_or_scorer_data,
+            execution_trace=execution_trace,
         )
 
         draft_categorizations = await Runner.run(
@@ -1011,6 +1025,7 @@ async def run_draft_categorization(
     model: str,
     max_concurrent_llm_calls: int,
     debug: bool = False,
+    deep_trace_analysis: bool = False,
 ) -> list[FirstPassCategorizationResult]:
     # Create shared semaphore for all draft categorization tasks
     llm_semaphore = Semaphore(max_concurrent_llm_calls)
@@ -1026,6 +1041,7 @@ async def run_draft_categorization(
             model=model,
             debug=debug,
             llm_semaphore=llm_semaphore,
+            execution_trace=trace_entry.get("execution_trace") if deep_trace_analysis else None,
         )
         for trace_entry in trace_data
     ]
@@ -1041,6 +1057,7 @@ def construct_final_classification_prompt(
     evaluation_evaluation_or_scorer_data: str | dict,
     user_context: str,
     available_categories_str: str,
+    execution_trace: str | None = None,
 ) -> str:
     # Convert dictionaries to JSON strings if needed
     if isinstance(row_input, dict):
@@ -1052,12 +1069,21 @@ def construct_final_classification_prompt(
             evaluation_evaluation_or_scorer_data, indent=2
         )
 
+    # Build execution trace section if provided
+    if execution_trace:
+        execution_trace_section = EXECUTION_TRACE_SECTION.format(
+            execution_trace=execution_trace
+        )
+    else:
+        execution_trace_section = ""
+
     final_classification_prompt_str = FINAL_CLASSIFICATION_PROMPT.format(
         user_context=user_context,
         row_input=row_input,
         row_output=row_output,
         evaluation_evaluation_or_scorer_data=evaluation_evaluation_or_scorer_data,
         available_failure_categories=available_categories_str,
+        execution_trace_section=execution_trace_section,
     )
     return final_classification_prompt_str
 
@@ -1072,6 +1098,7 @@ async def final_classification(
     available_categories_str: str,
     model: str,
     llm_semaphore: Semaphore,
+    execution_trace: str | None = None,
 ) -> FinalClassificationResult:
     async with llm_semaphore:
         final_classification_llm = Agent(
@@ -1087,6 +1114,7 @@ async def final_classification(
             evaluation_evaluation_or_scorer_data=evaluation_evaluation_or_scorer_data,
             user_context=user_context,
             available_categories_str=available_categories_str,
+            execution_trace=execution_trace,
         )
 
         classification_result = await Runner.run(
@@ -1112,6 +1140,7 @@ async def run_final_classification(
     model: str,
     max_concurrent_llm_calls: int,
     debug: bool = False,
+    deep_trace_analysis: bool = False,
 ) -> list[FinalClassificationResult]:
     # Create shared semaphore for all final classification tasks
     llm_semaphore = Semaphore(max_concurrent_llm_calls)
@@ -1126,6 +1155,7 @@ async def run_final_classification(
             available_categories_str=available_categories_str,
             model=model,
             llm_semaphore=llm_semaphore,
+            execution_trace=trace_entry.get("execution_trace") if deep_trace_analysis else None,
         )
         for trace_entry in trace_data
     ]
@@ -1188,10 +1218,14 @@ async def run_pipeline(
     max_concurrent_llm_calls: int,
     debug: bool = False,
     console: Console = Console(),
+    deep_trace_analysis: bool = False,
 ) -> PipelineResult:
     # ----------------- STEP 1: Draft categorization -----------------
     console.print("\n[bold cyan]Step 1: Draft Categorization[/bold cyan]")
     console.print(f"[bright_magenta]  Starting draft categorization for {len(trace_data)} traces...[/bright_magenta]")
+    
+    if deep_trace_analysis:
+        console.print("[dim]  Deep trace analysis enabled - including execution traces in prompts[/dim]")
 
     if debug:
         first_pass_categorization_prompt_str = (
@@ -1200,6 +1234,7 @@ async def run_pipeline(
                 row_output=trace_data[0]["output"],
                 evaluation_evaluation_or_scorer_data=trace_data[0]["scores"],
                 user_context=user_context,
+                execution_trace=trace_data[0].get("execution_trace") if deep_trace_analysis else None,
             )
         )
         console.print(
@@ -1229,6 +1264,7 @@ async def run_pipeline(
         model=model,
         max_concurrent_llm_calls=max_concurrent_llm_calls,
         debug=debug,
+        deep_trace_analysis=deep_trace_analysis,
     )
 
     num_draft_categorizations = len(draft_categorization_results)
@@ -1385,6 +1421,7 @@ async def run_pipeline(
         model=model,
         max_concurrent_llm_calls=max_concurrent_llm_calls,
         debug=debug,
+        deep_trace_analysis=deep_trace_analysis,
     )
     
     classification_spinner.stop("Classification complete", success=True)
@@ -1408,6 +1445,10 @@ async def run_extract_and_classify_pipeline(
     wandb_project: str,
     force_eval_select: bool = False,
     n_samples: int | None = None,
+    deep_trace_analysis: bool = False,
+    nesting_depth: int = 2,
+    max_trace_tokens: int = 2000,
+    compaction_model: str = DEFAULT_COMPACTION_MODEL,
 ) -> PipelineResult:
     # Query Weave for evaluation data using the enhanced API
     console = Console()
@@ -1428,6 +1469,19 @@ async def run_extract_and_classify_pipeline(
                 border_style="white",
                 padding=(1, 2),
                 width=105,
+            )
+        )
+    
+    if deep_trace_analysis:
+        console.print(
+            Panel(
+                f"[bold]Deep Trace Analysis:[/bold] Enabled\n"
+                f"[bold]Nesting Depth:[/bold] {nesting_depth}\n"
+                f"[bold]Max Trace Tokens:[/bold] {max_trace_tokens}\n"
+                f"[bold]Compaction Model:[/bold] {compaction_model}",
+                title="Deep Trace Analysis Settings",
+                border_style="cyan",
+                padding=(1, 2),
             )
         )
     
@@ -1482,7 +1536,16 @@ async def run_extract_and_classify_pipeline(
 
     # Prepare trace data for pipeline
     trace_data = prepare_trace_data_for_pipeline(
-        eval_data, debug, console, n_samples=n_samples
+        eval_data, 
+        debug, 
+        console, 
+        n_samples=n_samples,
+        deep_trace_analysis=deep_trace_analysis,
+        nesting_depth=nesting_depth,
+        max_trace_tokens=max_trace_tokens,
+        wandb_entity=wandb_entity,
+        wandb_project=wandb_project,
+        compaction_model=compaction_model,
     )
 
     console.print("")  # Add spacing before pipeline execution
@@ -1495,6 +1558,7 @@ async def run_extract_and_classify_pipeline(
         max_concurrent_llm_calls=max_concurrent_llm_calls,
         debug=debug,
         console=console,
+        deep_trace_analysis=deep_trace_analysis,
     )
     final_classification_results = pipeline_result.classifications
     all_categories = pipeline_result.failure_categories

--- a/fails/pipeline.py
+++ b/fails/pipeline.py
@@ -263,6 +263,9 @@ class Args:
     n_samples: int | None = None
     max_concurrent_llm_calls: int = 20  # Control concurrent LLM API calls
     eval_id: str | None = None  # Optional evaluation ID to skip interactive selection
+    deep_trace_analysis: bool = False  # Enable deep trace analysis for agentic workflows
+    nesting_depth: int = 2  # How deep to traverse nested traces (1=children, 2=grandchildren, etc.)
+    max_trace_tokens: int = 2000  # Token threshold before LLM compaction kicks in
 
 
 @weave.op
@@ -1848,5 +1851,8 @@ if __name__ == "__main__":
             wandb_entity=final_wandb_entity,
             wandb_project=final_wandb_project,
             n_samples=args.n_samples,
+            deep_trace_analysis=args.deep_trace_analysis,
+            nesting_depth=args.nesting_depth,
+            max_trace_tokens=args.max_trace_tokens,
         )
     )

--- a/fails/prompts.py
+++ b/fails/prompts.py
@@ -95,7 +95,7 @@ their AI system.
 <evaluation_evaluation_or_scorer_data>
 {evaluation_evaluation_or_scorer_data}
 </evaluation_evaluation_or_scorer_data>
-
+{execution_trace_section}
 ## Analyse and Draft Notes and Candidate Task Failure Categories
 
 With the above user context and evaluation failure data, please output a draft set of notes and candidate \
@@ -113,6 +113,31 @@ Ensure that the candidate task failure categories are:
 - lowercase
 - separated by underscores
 - no more than 5 words maximum
+"""
+
+
+# Execution trace section template - only included when deep_trace_analysis is enabled
+EXECUTION_TRACE_SECTION = """
+
+### Agent Execution Trace (showing internal decision-making process)
+
+The following trace shows the internal execution flow of the agent, including tool calls, their inputs/outputs, and the sequence of operations.
+
+Look for these trace-observable failure patterns:
+
+**Tool Use Failures:**
+- Wrong tool choice — Used tool X when tool Y was better suited
+- Bad tool input — Right tool, but malformed or suboptimal parameters
+- Ignored/misinterpreted tool output — Didn't incorporate or misread tool results
+- Redundant tool calls — Called the same thing multiple times unnecessarily
+
+**Planning Failures:**
+- Stuck in loop — Repeated the same action/pattern without progress
+- Poor ordering — Did things in an inefficient or illogical sequence
+
+<agent_execution_trace>
+{execution_trace}
+</agent_execution_trace>
 """
 
 
@@ -264,7 +289,7 @@ classify this specific failure into the most appropriate category.
 <evaluation_evaluation_or_scorer_data>
 {evaluation_evaluation_or_scorer_data}
 </evaluation_evaluation_or_scorer_data>
-
+{execution_trace_section}
 ## Available Failure Categories
 
 <available_failure_categories>

--- a/fails/prompts.py
+++ b/fails/prompts.py
@@ -141,6 +141,39 @@ Look for these trace-observable failure patterns:
 """
 
 
+# =============================================================================
+# Trace Compaction Prompts
+# =============================================================================
+
+# Default model for trace compaction
+DEFAULT_COMPACTION_MODEL = "gpt-4o-mini"
+
+TRACE_COMPACTION_SYSTEM_PROMPT = """You are compacting an agent execution trace for failure analysis.
+
+Your task is to summarize this execution trace concisely while preserving critical information.
+
+PRESERVE (keep exactly as-is or with minimal reduction):
+- All tool call names and their key input parameters
+- Errors, exceptions, or failure indicators
+- Key decision points and reasoning from LLM calls
+- Final outputs and results
+- The hierarchical structure of the trace
+
+SUMMARIZE/TRUNCATE:
+- Verbose intermediate LLM outputs (keep just key decisions)
+- Large data payloads in outputs (summarize what type of data)
+- Redundant or repetitive information
+- Long lists or arrays (indicate count and type)
+
+Output a condensed version of the trace that maintains the tree structure but is more compact."""
+
+TRACE_COMPACTION_USER_PROMPT = """Summarize this agent execution trace:
+
+{trace_tree}
+
+Output the compacted trace maintaining the tree structure."""
+
+
 class FirstPassCategory(BaseModel):
     """A first pass categorization of a single evaluation failure."""
 

--- a/fails/utils.py
+++ b/fails/utils.py
@@ -1,12 +1,21 @@
+import json
+import os
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+import litellm
 import weave
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from fails.prompts import Category, FinalClassificationResult
+from fails.prompts import (
+    Category, 
+    FinalClassificationResult,
+    DEFAULT_COMPACTION_MODEL,
+    TRACE_COMPACTION_SYSTEM_PROMPT,
+    TRACE_COMPACTION_USER_PROMPT,
+)
 
 
 @weave.op
@@ -104,7 +113,13 @@ def prepare_trace_data_for_pipeline(
     eval_data: Dict[str, Any],
     debug: bool,
     console: Console,
-    n_samples: int | None = None
+    n_samples: int | None = None,
+    deep_trace_analysis: bool = False,
+    nesting_depth: int = 2,
+    max_trace_tokens: int = 2000,
+    wandb_entity: str = "",
+    wandb_project: str = "",
+    compaction_model: str = DEFAULT_COMPACTION_MODEL,
 ) -> List[Dict[str, Any]]:
     """
     Prepare trace data from evaluation data for pipeline processing.
@@ -113,6 +128,13 @@ def prepare_trace_data_for_pipeline(
         eval_data: The evaluation data dictionary
         debug: Whether to display debug information
         console: Rich console for output
+        n_samples: Maximum number of samples to process
+        deep_trace_analysis: Whether to include nested trace execution trees
+        nesting_depth: How deep to traverse when fetching nested traces (1=children, 2=grandchildren, etc.)
+        max_trace_tokens: Token threshold for compaction
+        wandb_entity: Weave entity name (required if deep_trace_analysis=True)
+        wandb_project: Weave project name (required if deep_trace_analysis=True)
+        compaction_model: LLM model to use for trace compaction
         
     Returns:
         List of trace entries formatted for the pipeline
@@ -132,6 +154,10 @@ def prepare_trace_data_for_pipeline(
             console.print(
                 f"[dim]{len(eval_data['children'])} children found, sampling first {n_samples}:[/dim]\n"
             )
+            if deep_trace_analysis:
+                console.print(
+                    f"[dim]Deep trace analysis enabled with nesting_depth={nesting_depth}[/dim]\n"
+                )
         
         for i, trace in enumerate(eval_data["children"]):
             # Format trace entry for pipeline
@@ -141,6 +167,50 @@ def prepare_trace_data_for_pipeline(
                 "output": trace.get("output", {}),
                 "scores": trace.get("output", {}).get("scores", {}) if trace.get("output") else {},
             }
+            
+            # Add execution trace if deep analysis is enabled
+            if deep_trace_analysis:
+                if not wandb_entity or not wandb_project:
+                    console.print("[yellow]Warning: deep_trace_analysis requires wandb_entity and wandb_project[/yellow]")
+                else:
+                    try:
+                        # Fetch nested traces for this child
+                        nested_traces = get_nested_traces_for_child(
+                            child_trace_id=trace["id"],
+                            wandb_entity=wandb_entity,
+                            wandb_project=wandb_project,
+                            max_depth=nesting_depth,
+                        )
+                        
+                        if nested_traces:
+                            # Format as tree
+                            execution_tree = format_trace_as_tree(
+                                root_trace=trace,
+                                all_traces=nested_traces,
+                                max_depth=nesting_depth,
+                                include_inputs=True,
+                                include_outputs=True,
+                            )
+                            
+                            # Compact if too large
+                            execution_tree = compact_execution_trace(
+                                trace_tree=execution_tree,
+                                model=compaction_model,
+                                max_tokens=max_trace_tokens,
+                            )
+                            
+                            trace_entry["execution_trace"] = execution_tree
+                            
+                            if debug and i == 0:
+                                console.print(f"[dim]Execution trace for first child ({len(nested_traces)} nested traces):[/dim]")
+                                console.print(Panel(execution_tree[:2000] + ("..." if len(execution_tree) > 2000 else ""), 
+                                                   title="Execution Trace Preview", border_style="dim"))
+                        else:
+                            trace_entry["execution_trace"] = None
+                            
+                    except Exception as e:
+                        console.print(f"[yellow]Warning: Failed to fetch nested traces for {trace['id']}: {e}[/yellow]")
+                        trace_entry["execution_trace"] = None
             
             trace_data.append(trace_entry)
             
@@ -566,3 +636,272 @@ def generate_evaluation_report(
     report += "[bold bright_magenta]END REPORT[/bold bright_magenta]\n"
 
     return report
+
+
+# =============================================================================
+# Deep Trace Analysis Utilities
+# =============================================================================
+
+def estimate_token_count(text: str) -> int:
+    """
+    Estimate token count using character-based heuristic.
+    
+    Uses rough approximation: 4 characters ≈ 1 token, plus 10% overhead.
+    
+    Args:
+        text: The text to estimate tokens for
+        
+    Returns:
+        Estimated token count
+    """
+    base_estimate = len(text) / 4
+    with_overhead = base_estimate * 1.1
+    return int(with_overhead)
+
+
+def get_op_short_name(op_name: str) -> str:
+    """
+    Extract short name from full op_name like 'weave:///entity/project/op/Name:hash'.
+    
+    Args:
+        op_name: Full Weave op name URI
+        
+    Returns:
+        Short op name (e.g., "NotionRAGAgent.call_model")
+    """
+    if not op_name:
+        return "Unknown"
+    # Extract the op name part before the hash
+    if "/op/" in op_name:
+        name_with_hash = op_name.split("/op/")[-1]
+        return name_with_hash.split(":")[0]
+    return op_name
+
+
+def calculate_duration(trace: Dict[str, Any]) -> str:
+    """
+    Calculate duration string from started_at and ended_at timestamps.
+    
+    Args:
+        trace: Trace dictionary with started_at and ended_at fields
+        
+    Returns:
+        Duration string (e.g., "1.13s" or "497ms")
+    """
+    started = trace.get("started_at")
+    ended = trace.get("ended_at")
+    if not started or not ended:
+        return ""
+    
+    try:
+        # Parse ISO format timestamps
+        start_dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
+        end_dt = datetime.fromisoformat(ended.replace("Z", "+00:00"))
+        duration_ms = (end_dt - start_dt).total_seconds() * 1000
+        
+        if duration_ms >= 1000:
+            return f"{duration_ms/1000:.2f}s"
+        else:
+            return f"{duration_ms:.0f}ms"
+    except Exception:
+        return ""
+
+
+def _format_value_for_tree(value: Any, indent: str = "", max_length: int = 500) -> str:
+    """
+    Format a value for display in the tree, truncating if necessary.
+    
+    Args:
+        value: The value to format
+        indent: Current indentation string
+        max_length: Maximum length before truncation
+        
+    Returns:
+        Formatted string representation
+    """
+    try:
+        if value is None:
+            return "null"
+        formatted = json.dumps(value, indent=2, default=str)
+        # Add indentation to all lines
+        lines = formatted.split('\n')
+        if len(lines) > 1:
+            formatted = lines[0] + '\n' + '\n'.join(indent + '  ' + line for line in lines[1:])
+        # Truncate if too long
+        if len(formatted) > max_length:
+            formatted = formatted[:max_length] + "... [truncated]"
+        return formatted
+    except Exception:
+        return str(value)[:max_length]
+
+
+def format_trace_as_tree(
+    root_trace: Dict[str, Any],
+    all_traces: List[Dict[str, Any]],
+    max_depth: Optional[int] = None,
+    include_inputs: bool = True,
+    include_outputs: bool = True,
+) -> str:
+    """
+    Format traces as an ASCII tree with full details.
+    
+    Args:
+        root_trace: The root trace to start from
+        all_traces: All descendant traces (flat list)
+        max_depth: Maximum depth to display (None for unlimited)
+        include_inputs: Whether to include input details
+        include_outputs: Whether to include output details
+        
+    Returns:
+        ASCII tree string representation
+    """
+    # Create a map of parent_id -> children
+    children_map: Dict[str, List[Dict[str, Any]]] = {}
+    for trace in all_traces:
+        parent_id = trace.get("parent_id")
+        if parent_id:
+            if parent_id not in children_map:
+                children_map[parent_id] = []
+            children_map[parent_id].append(trace)
+    
+    # Sort children by started_at
+    for parent_id in children_map:
+        children_map[parent_id].sort(key=lambda t: t.get("started_at", ""))
+    
+    lines = []
+    
+    def add_trace_to_tree(trace: Dict[str, Any], prefix: str = "", is_last: bool = True, depth: int = 0):
+        """Recursively add trace and its children to the tree."""
+        if max_depth is not None and depth > max_depth:
+            return
+            
+        # Determine tree characters
+        connector = "└── " if is_last else "├── "
+        child_prefix = prefix + ("    " if is_last else "│   ")
+        
+        # Format trace header
+        op_name = get_op_short_name(trace.get("op_name", ""))
+        duration = calculate_duration(trace)
+        
+        if depth == 0:
+            # Root trace - no connector
+            lines.append(f"{op_name} ({duration})")
+            current_prefix = ""
+        else:
+            lines.append(f"{prefix}{connector}{op_name} ({duration})")
+            current_prefix = child_prefix
+        
+        # Add inputs if present and requested
+        if include_inputs and trace.get("inputs"):
+            inputs_str = _format_value_for_tree(trace["inputs"], current_prefix)
+            lines.append(f"{current_prefix}├── inputs: {inputs_str}")
+        
+        # Add outputs if present and requested
+        if include_outputs and trace.get("output"):
+            output_str = _format_value_for_tree(trace["output"], current_prefix)
+            has_children = trace["id"] in children_map
+            output_connector = "├── " if has_children else "└── "
+            lines.append(f"{current_prefix}{output_connector}output: {output_str}")
+        
+        # Add exception if present
+        if trace.get("exception"):
+            lines.append(f"{current_prefix}└── [ERROR] {trace['exception']}")
+        
+        # Process children
+        children = children_map.get(trace["id"], [])
+        for i, child in enumerate(children):
+            is_last_child = (i == len(children) - 1)
+            add_trace_to_tree(child, current_prefix, is_last_child, depth + 1)
+    
+    add_trace_to_tree(root_trace, depth=0)
+    return "\n".join(lines)
+
+
+def get_nested_traces_for_child(
+    child_trace_id: str,
+    wandb_entity: str,
+    wandb_project: str,
+    max_depth: int = 3,
+    columns: Optional[List[str]] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Fetch all nested descendants for a single child trace.
+    
+    Args:
+        child_trace_id: The trace ID to fetch descendants for
+        wandb_entity: Weave entity name
+        wandb_project: Weave project name
+        max_depth: Maximum depth to traverse
+        columns: Columns to retrieve
+        
+    Returns:
+        List of all descendant traces
+    """
+    # Import here to avoid circular imports
+    from fails.weave_query import WeaveQueryConfig, WeaveQueryClient
+    
+    if columns is None:
+        columns = [
+            "id", "parent_id", "trace_id", "op_name", 
+            "started_at", "ended_at", "inputs", "output", "exception"
+        ]
+    
+    config = WeaveQueryConfig(wandb_entity=wandb_entity, wandb_project=wandb_project)
+    client = WeaveQueryClient(config)
+    
+    # Use recursive query
+    result = client.query_descendants_recursive(
+        parent_id=child_trace_id,
+        columns=columns,
+        max_depth=max_depth,
+    )
+    
+    return result.get("traces", [])
+
+
+@weave.op
+def compact_execution_trace(
+    trace_tree: str,
+    model: str = DEFAULT_COMPACTION_MODEL,
+    max_tokens: int = 2000,
+) -> str:
+    """
+    Use LLM to intelligently summarize large execution traces.
+    
+    Preserves key information like tool calls, errors, and decisions
+    while summarizing verbose intermediate outputs.
+    
+    Args:
+        trace_tree: The formatted trace tree string
+        model: LLM model to use for compaction (default from prompts.DEFAULT_COMPACTION_MODEL)
+        max_tokens: Token threshold - if below this, no compaction
+        
+    Returns:
+        Compacted trace tree string (or original if under threshold)
+    """
+    estimated_tokens = estimate_token_count(trace_tree)
+    
+    if estimated_tokens <= max_tokens:
+        return trace_tree  # No compaction needed
+    
+    # Format the user prompt with the trace tree
+    user_prompt = TRACE_COMPACTION_USER_PROMPT.format(trace_tree=trace_tree)
+
+    try:
+        response = litellm.completion(
+            model=model,
+            messages=[
+                {"role": "system", "content": TRACE_COMPACTION_SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+            max_tokens=max_tokens,
+        )
+        return response.choices[0].message.content
+    except Exception as e:
+        # If compaction fails, return truncated original
+        Console().print(f"[yellow]Warning: Trace compaction failed: {e}. Using truncated trace.[/yellow]")
+        # Simple truncation fallback
+        max_chars = max_tokens * 4
+        if len(trace_tree) > max_chars:
+            return trace_tree[:max_chars] + "\n... [trace truncated due to size]"
+        return trace_tree


### PR DESCRIPTION
# Deep Trace Analysis for Fails Pipeline

## Problem

The current `fails` pipeline only analyzes **inputs and outputs** of evaluation samples. This is a "black box" view - we see what went in and what came out, but not *how* the agent arrived at that output.

For agentic workflows, failures often happen in the middle:
- Wrong tool was selected
- Tool was called with bad parameters  
- Agent got stuck in a loop
- Agent ignored useful tool output

Without seeing the execution trace, these failure modes are invisible.

## Solution

This PR adds **deep trace analysis** - an optional feature that fetches the full nested execution tree for each sample and includes it in the LLM prompts for failure categorization.

### Before
```
Prompt sees:
- inputs: {"query": "How do I..."}
- outputs: {"response": "Wrong answer"}
- scores: {"correct": false}
```

### After (with deep_trace_analysis=True)
```
Prompt sees:
- inputs: {"query": "How do I..."}
- outputs: {"response": "Wrong answer"}  
- scores: {"correct": false}
- execution_trace:
    OrchestratorAgent.generate (40.27s)
    └── call_model (497ms)
        └── openai.chat.completions.create
    └── perform_tool_calls_parallel (8.00s)
        └── search_tool (857ms)
            ├── inputs: {"query": "wrong search term"}  ← Now visible!
            └── output: {"results": []}
    └── call_model (6.04s)
        └── [ignored the empty results, hallucinated answer]
```

## Files Changed

| File | Changes |
|------|---------|
| `fails/pipeline.py` | Added `deep_trace_analysis`, `nesting_depth`, `max_trace_tokens` params to `run_pipeline` and `run_extract_and_classify_pipeline`. Updated prompt construction to include execution trace. |
| `fails/utils.py` | Added `format_trace_as_tree()`, `get_nested_traces_for_child()`, `compact_execution_trace()`, `estimate_token_count()`. Updated `prepare_trace_data_for_pipeline()` to fetch nested traces. |
| `fails/prompts.py` | Added `EXECUTION_TRACE_SECTION` template, `TRACE_COMPACTION_SYSTEM_PROMPT`, `TRACE_COMPACTION_USER_PROMPT`, `DEFAULT_COMPACTION_MODEL`. |

## Configuration

| Parameter | Default | Description |
|-----------|---------|-------------|
| `deep_trace_analysis` | `False` | Enable/disable the feature |
| `nesting_depth` | `2` | How deep to fetch (1=children, 2=grandchildren, etc.) |
| `max_trace_tokens` | `2000` | Token threshold before LLM compaction kicks in |
| `compaction_model` | `gpt-4o-mini` | Model used for trace compaction (configurable via `DEFAULT_COMPACTION_MODEL` in `prompts.py`) |

## Usage

### CLI
```bash
python fails/pipeline.py --deep_trace_analysis --eval_id YOUR_EVAL_ID

# With custom settings
python fails/pipeline.py \
    --deep_trace_analysis \
    --nesting_depth 3 \
    --max_trace_tokens 3000 \
    --debug \
    --eval_id YOUR_EVAL_ID
```

### Programmatic
```python
result = await run_extract_and_classify_pipeline(
    eval_id="your-eval-id",
    wandb_entity="your-entity",
    wandb_project="your-project",
    user_context="Context about your agent...",
    # ... other params ...
    
    # Deep trace analysis options
    deep_trace_analysis=True,
    nesting_depth=2,
    max_trace_tokens=2000,
)
```

## Notes for Reviewers

- **Backwards compatible**: `deep_trace_analysis=False` by default, existing behavior unchanged.
- **Entity/Project handling**: Currently requires explicit `wandb_entity` and `wandb_project`. Generic Weave link parsing is handled separately.
- **Compaction**: Large traces are automatically summarized by an LLM to prevent context window overflow while preserving key information (tool calls, errors, decisions).

## How to Test

1. Run the pipeline on an agentic evaluation with `deep_trace_analysis=True`
2. Check debug output - you should see "Execution trace for first child (X nested traces)"
3. Verify the prompt includes the `<agent_execution_trace>` section
